### PR TITLE
Drop unicode_literals in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from os.path import abspath, dirname, join
 from setuptools import setup
 
@@ -26,7 +25,7 @@ if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
                      'Programming Language :: Python :: 2.7',
                      'Programming Language :: Python :: 3'],
         keywords='django wsgi x509 auth',
-        author='Rémy Hubscher',
+        author=u'Rémy Hubscher',
         author_email='hubscher.remy@gmail.com',
         url='https://github.com/novapost/django-x509',
         license='MIT Licence',


### PR DESCRIPTION
Here is the error encountered :

```
python setup.py bdist                                                              
running bdist
running bdist_dumb
running build
running build_py
Traceback (most recent call last):
  File "setup.py", line 40, in <module>
    'test_app = x509.test_app:main',
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/distutils/command/bdist.py", line 146, in run
    self.run_command(cmd_name)
  File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/distutils/command/bdist_dumb.py", line 86, in run
    self.run_command('build')
  File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/distutils/command/build.py", line 128, in run
    self.run_command(cmd_name)
  File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.7/dist-packages/setuptools/command/build_py.py", line 46, in run
    self.build_packages()
  File "/usr/lib/python2.7/distutils/command/build_py.py", line 373, in build_packages
    self.build_module(module, module_file, package)
  File "/usr/lib/python2.7/dist-packages/setuptools/command/build_py.py", line 65, in build_module
    package)
  File "/usr/lib/python2.7/distutils/command/build_py.py", line 334, in build_module
    "'package' must be a string (dot-separated), list, or tuple")
TypeError: 'package' must be a string (dot-separated), list, or tuple
```
