### PR TITLE
Explicit on_delete behaviour for ForeignKeys.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Changelog for django-x509
 ----------------
 
 - Add Python3 and Django 1.10 support.
+- Explicit on_delete behaviour for ForeignKeys
 
 
 0.4 (2017-06-21)

--- a/x509/django/models.py
+++ b/x509/django/models.py
@@ -24,8 +24,9 @@ class Certificate(models.Model):
 
 class GenericCertificateM2M(models.Model):
     """Link a Certificate to any other object (User, object)."""
-    certificate = models.ForeignKey(Certificate, related_name='attachees')
-    content_type = models.ForeignKey(ContentType)
+    certificate = models.ForeignKey(Certificate, related_name='attachees',
+                                    on_delete=models.CASCADE)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey('content_type', 'object_id')
 


### PR DESCRIPTION
RemovedInDjango20Warning: on_delete will be a required arg for ForeignKey in Django 2.0.
Set it to models.CASCADE on models and in existing migrations if you want to maintain the current default behavior.
See https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.ForeignKey.on_delete